### PR TITLE
Fix jv.jl

### DIFF
--- a/jv/jv.jl
+++ b/jv/jv.jl
@@ -205,8 +205,8 @@ function bellman_operator!(jv::JvWorker, V::Vector,
             s, phi = z
             function h(u)
               out = similar(u)
-              for i in 1:length(u)
-                out[i] = Vf[max(G(x, phi), u[i])] * pdf(F, u[i])
+              for j in 1:length(u)
+                out[j] = Vf[max(G(x, phi), u[j])] * pdf(F, u[j])
               end
               out
             end

--- a/jv/jv.jl
+++ b/jv/jv.jl
@@ -262,7 +262,7 @@ Extract the greedy policy (policy function) of the model.
 
 ##### Arguments
 
-- `cp::JvWorker` : Instance of `CareerWorkerProblem`
+- `cp::JvWorker` : Instance of `JvWorker`
 - `v::Vector`: Current guess for the value function
 - `out::Tuple(Vector, Vector)` : Storage for output of policy rule
 

--- a/jv/jv.jl
+++ b/jv/jv.jl
@@ -109,33 +109,25 @@ end
 # make kwarg version
 JvWorker(;A=1.4, alpha=0.6, bet=0.96, grid_size=50, epsilon=1e-4) = JvWorker(A, alpha, bet, grid_size, epsilon)
 
-# NOTE: this function is not type stable because it returns either
-#       Array{Float64, 2} or (Array{Float64, 2}, Array{Float64, 2})
-#       depending on the value of ret_policies. This is probably not a
-#       huge deal, but it is something to be aware of
 """
-Apply the Bellman operator for a given model and initial value.
+Apply the Bellman operator for a given model and initial value, returning only the value function
 
 ##### Arguments
 
 - `jv::JvWorker` : Instance of `JvWorker`
 - `V::Vector`: Current guess for the value function
-- `out::Union{Vector, Tuple{Vector, Vector}}` : Storage for output. Note that
-there are two policy rules, but one value function
-- `;ret_policy::Bool(false)`: Toggles return of value or policy functions
+- `new_V::Vector` : Storage for updated value function
 
 ##### Returns
 
-None, `out` is updated in place. If `ret_policy == true` out is filled with the
-policy function, otherwise the value function is stored in `out`.
+None, `new_V` is updated in place with the value function.
 
 ##### Notes
 
 Currently, only the brute-force approach is available. We are waiting on a simple constrained optimizer to be written in pure Julia
 
 """
-function bellman_operator!(jv::JvWorker, V::Vector,
-                           out::Union{Vector, Tuple{Vector, Vector}}; ret_policies=false)
+function bellman_operator!(jv::JvWorker, V::Vector, new_V::Vector)
 
     # simplify notation
     G, pi_func, F, bet, epsilon = jv.G, jv.pi_func, jv.F, jv.bet, jv.epsilon
@@ -143,29 +135,6 @@ function bellman_operator!(jv::JvWorker, V::Vector,
 
     # prepare interpoland of value function
     Vf = extrapolate(interpolate((jv.x_grid, ), V, Gridded(Linear())), Flat())
-
-    # instantiate variables so they are available outside loop and exist
-    # within it
-    if ret_policies
-        if !(typeof(out) <: Tuple{Vector, Vector})
-            msg = "You asked for policies, but only provided one output array"
-            msg *= "\nthere are two policies so two arrays must be given"
-            error(msg)
-        end
-        s_policy, phi_policy = out[1], out[2]
-    else
-        c1(z) = 1.0 - sum(z)
-        c2(z) = z[1] - epsilon
-        c3(z) = z[2] - epsilon
-        guess = (0.2, 0.2)
-        constraints = [Dict("type" => "ineq", "fun"=> i) for i in [c1, c2, c3]]
-        if typeof(out) <: Tuple
-            msg = "Multiple output arrays given. There is only one value"
-            msg = " function.\nDid you mean to pass ret_policies=true?"
-            error(msg)
-        end
-        new_V = out
-    end
 
     # instantiate the linesearch variables
     max_val = -1.0
@@ -204,14 +173,80 @@ function bellman_operator!(jv::JvWorker, V::Vector,
             end
         end
 
-        if ret_policies
-            s_policy[i], phi_policy[i] = max_s, max_phi
-        else
-            new_V[i] = max_val
-        end
+        new_V[i] = max_val
     end
 end
 
+"""
+Apply the Bellman operator for a given model and initial value, returning policies
+
+##### Arguments
+
+- `jv::JvWorker` : Instance of `JvWorker`
+- `V::Vector`: Current guess for the value function
+- `out::Tuple{Vector, Vector}` : Storage for the two policy rules
+
+##### Returns
+
+None, `out` is updated in place with the two policy functions.
+
+##### Notes
+
+Currently, only the brute-force approach is available. We are waiting on a simple constrained optimizer to be written in pure Julia
+
+"""
+function bellman_operator!(jv::JvWorker, V::Vector, out::Tuple{Vector, Vector})
+
+    # simplify notation
+    G, pi_func, F, bet, epsilon = jv.G, jv.pi_func, jv.F, jv.bet, jv.epsilon
+    nodes, weights = jv.quad_nodes, jv.quad_weights
+
+    # prepare interpoland of value function
+    Vf = extrapolate(interpolate((jv.x_grid, ), V, Gridded(Linear())), Flat())
+
+    # instantiate variables
+    s_policy, phi_policy = out[1], out[2]
+
+    # instantiate the linesearch variables
+    max_val = -1.0
+    cur_val = 0.0
+    max_s = 1.0
+    max_phi = 1.0
+    search_grid = linspace(epsilon, 1.0, 15)
+
+    for (i, x) in enumerate(jv.x_grid)
+
+        function w(z)
+            s, phi = z
+            function h(u)
+              out = similar(u)
+              for j in 1:length(u)
+                out[j] = Vf[max(G(x, phi), u[j])] * pdf(F, u[j])
+              end
+              out
+            end
+            integral = do_quad(h, nodes, weights)
+            q = pi_func(s) * integral + (1.0 - pi_func(s)) * Vf[G(x, phi)]
+
+            return - x * (1.0 - phi - s) - bet * q
+        end
+
+        for s in search_grid
+            for phi in search_grid
+                if s + phi <= 1.0
+                    cur_val = -w((s, phi))
+                else
+                    cur_val = -1.0
+                end
+                if cur_val > max_val
+                    max_val, max_s, max_phi = cur_val, s, phi
+                end
+            end
+        end
+
+      s_policy[i], phi_policy[i] = max_s, max_phi
+  end
+end
 
 function bellman_operator(jv::JvWorker, V::Vector; ret_policies=false)
     if ret_policies
@@ -219,28 +254,6 @@ function bellman_operator(jv::JvWorker, V::Vector; ret_policies=false)
     else
         out = similar(V)
     end
-    bellman_operator!(jv, V, out, ret_policies=ret_policies)
+    bellman_operator!(jv, V, out)
     return out
-end
-
-"""
-Extract the greedy policy (policy function) of the model.
-
-##### Arguments
-
-- `cp::JvWorker` : Instance of `JvWorker`
-- `v::Vector`: Current guess for the value function
-- `out::Tuple(Vector, Vector)` : Storage for output of policy rule
-
-##### Returns
-
-None, `out` is updated in place to hold the policy function
-
-"""
-function get_greedy!(jv::JvWorker, V::Vector, out::Tuple{Vector, Vector})
-    bellman_operator!(jv, V, out, ret_policies=true)
-end
-
-function get_greedy(jv::JvWorker, V::Vector)
-    bellman_operator(jv, V, ret_policies=true)
 end

--- a/jv/jv_test.jl
+++ b/jv/jv_test.jl
@@ -1,5 +1,5 @@
 using QuantEcon
-using PyPlot
+using PlotlyJS
 
 include("jv.jl")
 
@@ -9,13 +9,18 @@ v_init = wp.x_grid .* 0.5
 f(x) = bellman_operator(wp, x)
 V = compute_fixed_point(f, v_init, max_iter=40)
 
-s_policy, phi_policy = bellman_operator(wp, V, return_policies=true)
+s_policy, phi_policy = bellman_operator(wp, V, ret_policies=true)
 
 # === plot policies === #
-fig, ax = subplots()
-ax[:set_xlim](0, maximum(wp.x_grid))
-ax[:set_ylim](-0.1, 1.1)
-ax[:plot](wp.x_grid, phi_policy, "b-", label="phi")
-ax[:plot](wp.x_grid, s_policy, "g-", label="s")
-ax[:set_xlabel]("x")
-ax[:legend]()
+tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, label = "phi"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, label = "s"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+[tr_s; tr_phi]
+
+# === plot policies === #
+# fig, ax = subplots()
+# ax[:set_xlim](0, maximum(wp.x_grid))
+# ax[:set_ylim](-0.1, 1.1)
+# ax[:plot](wp.x_grid, phi_policy, "b-", label="phi")
+# ax[:plot](wp.x_grid, s_policy, "g-", label="s")
+# ax[:set_xlabel]("x")
+# ax[:legend]()

--- a/jv/jv_test.jl
+++ b/jv/jv_test.jl
@@ -7,14 +7,14 @@ wp = JvWorker(grid_size=25)
 v_init = wp.x_grid .* 0.5
 
 f(x) = bellman_operator(wp, x)
-V = compute_fixed_point(f, v_init, max_iter=40)
+V = compute_fixed_point(f, v_init, max_iter=200)
 
 s_policy, phi_policy = bellman_operator(wp, V, ret_policies=true)
 
 # === plot policies === #
-tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, label = "phi"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
-tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, label = "s"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
-[tr_s; tr_phi]
+tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, name = "phi"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, name = "s"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+display([tr_s; tr_phi])
 
 # === plot policies === #
 # fig, ax = subplots()

--- a/jv/jv_test.jl
+++ b/jv/jv_test.jl
@@ -15,12 +15,3 @@ s_policy, phi_policy = bellman_operator(wp, V, ret_policies=true)
 tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, name = "phi"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
 tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, name = "s"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
 display([tr_s; tr_phi])
-
-# === plot policies === #
-# fig, ax = subplots()
-# ax[:set_xlim](0, maximum(wp.x_grid))
-# ax[:set_ylim](-0.1, 1.1)
-# ax[:plot](wp.x_grid, phi_policy, "b-", label="phi")
-# ax[:plot](wp.x_grid, s_policy, "g-", label="s")
-# ax[:set_xlabel]("x")
-# ax[:legend]()

--- a/jv/jv_test.jl
+++ b/jv/jv_test.jl
@@ -11,7 +11,8 @@ V = compute_fixed_point(f, v_init, max_iter=200)
 
 s_policy, phi_policy = bellman_operator(wp, V, ret_policies=true)
 
-# === plot policies === #
-tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, name = "phi"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
-tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, name = "s"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
-display([tr_s; tr_phi])
+# === plot solution === #
+tr_phi = plot(scatter(; x = wp.x_grid, y = phi_policy, name = "ϕ policy"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+tr_s = plot(scatter(; x = wp.x_grid, y = s_policy, name = "s policy"), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], yaxis_range = [-0.1, 1.1], xaxis_title = "x"))
+tr_V = plot(scatter(; x = wp.x_grid, y = V, name = "Value Fn."), Layout(xaxis_range = [0.0, maximum(wp.x_grid)], xaxis_title = "x"))
+display([tr_s; tr_phi; tr_V])


### PR DESCRIPTION
I've substituted using `Grid.jl` with its newest version, `Interpolations.jl`. I also had to adjust indexing, as this code makes substantial use of global variables, and my first fix created a bug.

I also updated `jv_test.jl` to make plots using `PlotlyJS.jl`.

I compared the policies with the Python results from `jv_test.py`. Qualitatively the results are similar. Quantitatively they are close, but as the two versions of the code use different optimization algorithm, differences are not surprising. Actually, when I run `jv_test.py` I get a non-monotonicity in one of the policies, which is absent in the Julia equivalent - a good sign for the Julia code.